### PR TITLE
chore: merge canary into main for beta release

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Test
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches:
+      - main
+      - canary
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: setup-bun
+        uses: oven-sh/setup-bun@735343b667d3e6f658f44d0eca948eb6282f2b76 # v2.0.2
+        with:
+          bun-version: 1.3.3
+
+      - name: install
+        run: bun install --frozen-lockfile
+
+      - name: test
+        run: bun test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,5 +27,8 @@ jobs:
       - name: install
         run: bun install --frozen-lockfile
 
+      - name: build
+        run: bun run build
+
       - name: test
         run: bun test

--- a/bun.lock
+++ b/bun.lock
@@ -253,7 +253,7 @@
     },
     "packages/adapters": {
       "name": "@better-agent/adapters",
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.2",
       "devDependencies": {
         "@better-agent/core": "workspace:*",
         "@types/bun": "^1.2.18",
@@ -269,7 +269,7 @@
     },
     "packages/cli": {
       "name": "@better-agent/cli",
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.2",
       "bin": {
         "better-agent": "./dist/index.mjs",
       },
@@ -290,7 +290,7 @@
     },
     "packages/client": {
       "name": "@better-agent/client",
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.2",
       "dependencies": {
         "@better-agent/core": "workspace:*",
         "@better-agent/shared": "workspace:*",
@@ -326,7 +326,7 @@
     },
     "packages/core": {
       "name": "@better-agent/core",
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.2",
       "dependencies": {
         "@better-agent/shared": "workspace:*",
         "@standard-schema/spec": "1.1.0",
@@ -340,7 +340,7 @@
     },
     "packages/create": {
       "name": "create-better-agent",
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.2",
       "bin": {
         "create-better-agent": "./dist/index.mjs",
       },
@@ -356,7 +356,7 @@
     },
     "packages/plugins": {
       "name": "@better-agent/plugins",
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.2",
       "dependencies": {
         "@better-agent/shared": "workspace:*",
       },
@@ -370,7 +370,7 @@
     },
     "packages/providers": {
       "name": "@better-agent/providers",
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.2",
       "dependencies": {
         "@better-agent/shared": "workspace:*",
         "zod": "^4.1.13",
@@ -385,7 +385,7 @@
     },
     "packages/shared": {
       "name": "@better-agent/shared",
-      "version": "0.1.0-canary.0",
+      "version": "0.1.0-canary.2",
       "dependencies": {
         "neverthrow": "^8.2.0",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -114,10 +114,10 @@
     "examples/nuxt": {
       "name": "nuxt",
       "dependencies": {
-        "@better-agent/client": "^0.0.1",
-        "@better-agent/core": "^0.0.1",
-        "@better-agent/plugins": "^0.0.1",
-        "@better-agent/providers": "^0.0.1",
+        "@better-agent/client": "workspace:*",
+        "@better-agent/core": "workspace:*",
+        "@better-agent/plugins": "workspace:*",
+        "@better-agent/providers": "workspace:*",
         "@tailwindcss/postcss": "^4.1.18",
         "h3": "^1.15.11",
         "nuxt": "^4.3.1",
@@ -204,10 +204,10 @@
       "name": "svelte",
       "version": "0.1.0",
       "dependencies": {
-        "@better-agent/client": "^0.0.1",
-        "@better-agent/core": "^0.0.1",
-        "@better-agent/plugins": "^0.0.1",
-        "@better-agent/providers": "^0.0.1",
+        "@better-agent/client": "workspace:*",
+        "@better-agent/core": "workspace:*",
+        "@better-agent/plugins": "workspace:*",
+        "@better-agent/providers": "workspace:*",
         "tailwindcss": "^4.1.18",
       },
       "devDependencies": {
@@ -253,7 +253,7 @@
     },
     "packages/adapters": {
       "name": "@better-agent/adapters",
-      "version": "0.0.1",
+      "version": "0.1.0-canary.0",
       "devDependencies": {
         "@better-agent/core": "workspace:*",
         "@types/bun": "^1.2.18",
@@ -269,7 +269,7 @@
     },
     "packages/cli": {
       "name": "@better-agent/cli",
-      "version": "0.0.1",
+      "version": "0.1.0-canary.0",
       "bin": {
         "better-agent": "./dist/index.mjs",
       },
@@ -290,7 +290,7 @@
     },
     "packages/client": {
       "name": "@better-agent/client",
-      "version": "0.0.1",
+      "version": "0.1.0-canary.0",
       "dependencies": {
         "@better-agent/core": "workspace:*",
         "@better-agent/shared": "workspace:*",
@@ -326,7 +326,7 @@
     },
     "packages/core": {
       "name": "@better-agent/core",
-      "version": "0.0.1",
+      "version": "0.1.0-canary.0",
       "dependencies": {
         "@better-agent/shared": "workspace:*",
         "@standard-schema/spec": "1.1.0",
@@ -340,7 +340,7 @@
     },
     "packages/create": {
       "name": "create-better-agent",
-      "version": "0.0.1",
+      "version": "0.1.0-canary.0",
       "bin": {
         "create-better-agent": "./dist/index.mjs",
       },
@@ -356,7 +356,7 @@
     },
     "packages/plugins": {
       "name": "@better-agent/plugins",
-      "version": "0.0.1",
+      "version": "0.1.0-canary.0",
       "dependencies": {
         "@better-agent/shared": "workspace:*",
       },
@@ -370,7 +370,7 @@
     },
     "packages/providers": {
       "name": "@better-agent/providers",
-      "version": "0.0.1",
+      "version": "0.1.0-canary.0",
       "dependencies": {
         "@better-agent/shared": "workspace:*",
         "zod": "^4.1.13",
@@ -385,7 +385,7 @@
     },
     "packages/shared": {
       "name": "@better-agent/shared",
-      "version": "0.0.1",
+      "version": "0.1.0-canary.0",
       "dependencies": {
         "neverthrow": "^8.2.0",
       },

--- a/docs/app/_components/cta-section.tsx
+++ b/docs/app/_components/cta-section.tsx
@@ -281,6 +281,7 @@ export default function CtaSection() {
                     alt=""
                     aria-hidden="true"
                     className="pointer-events-none absolute inset-0 size-full object-cover object-top -z-1"
+                    loading="eager"
                     src="/cta-bg.png"
                     fill
                     style={{

--- a/examples/astro/package.json
+++ b/examples/astro/package.json
@@ -12,10 +12,10 @@
   "dependencies": {
     "@astrojs/node": "^10.0.4",
     "@astrojs/react": "^5.0.2",
-    "@better-agent/client": "^0.0.1",
-    "@better-agent/core": "^0.0.1",
-    "@better-agent/plugins": "^0.0.1",
-    "@better-agent/providers": "^0.0.1",
+    "@better-agent/client": "workspace:*",
+    "@better-agent/core": "workspace:*",
+    "@better-agent/plugins": "workspace:*",
+    "@better-agent/providers": "workspace:*",
     "astro": "^6.1.2",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/examples/generic/package.json
+++ b/examples/generic/package.json
@@ -7,9 +7,9 @@
     "typescript": "^5.9.3"
   },
   "dependencies": {
-    "@better-agent/client": "^0.0.1",
-    "@better-agent/core": "^0.0.1",
-    "@better-agent/plugins": "^0.0.1",
-    "@better-agent/providers": "^0.0.1"
+    "@better-agent/client": "workspace:*",
+    "@better-agent/core": "workspace:*",
+    "@better-agent/plugins": "workspace:*",
+    "@better-agent/providers": "workspace:*"
   }
 }

--- a/examples/nextjs/package.json
+++ b/examples/nextjs/package.json
@@ -9,10 +9,10 @@
     "lint": "eslint ."
   },
   "dependencies": {
-    "@better-agent/client": "^0.0.1",
-    "@better-agent/core": "^0.0.1",
-    "@better-agent/plugins": "^0.0.1",
-    "@better-agent/providers": "^0.0.1",
+    "@better-agent/client": "workspace:*",
+    "@better-agent/core": "workspace:*",
+    "@better-agent/plugins": "workspace:*",
+    "@better-agent/providers": "workspace:*",
     "geist": "1.7.0",
     "next": "16.2.1",
     "react": "19.2.4",

--- a/examples/nuxt/package.json
+++ b/examples/nuxt/package.json
@@ -11,10 +11,10 @@
     "postinstall": "nuxt prepare"
   },
   "dependencies": {
-    "@better-agent/client": "^0.0.1",
-    "@better-agent/core": "^0.0.1",
-    "@better-agent/plugins": "^0.0.1",
-    "@better-agent/providers": "^0.0.1",
+    "@better-agent/client": "workspace:*",
+    "@better-agent/core": "workspace:*",
+    "@better-agent/plugins": "workspace:*",
+    "@better-agent/providers": "workspace:*",
     "@tailwindcss/postcss": "^4.1.18",
     "h3": "^1.15.11",
     "nuxt": "^4.3.1",

--- a/examples/react-router/package.json
+++ b/examples/react-router/package.json
@@ -9,10 +9,10 @@
     "typecheck": "react-router typegen && tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@better-agent/client": "^0.0.1",
-    "@better-agent/core": "^0.0.1",
-    "@better-agent/plugins": "^0.0.1",
-    "@better-agent/providers": "^0.0.1",
+    "@better-agent/client": "workspace:*",
+    "@better-agent/core": "workspace:*",
+    "@better-agent/plugins": "workspace:*",
+    "@better-agent/providers": "workspace:*",
     "@react-router/node": "^7.0.0",
     "@react-router/serve": "^7.0.0",
     "isbot": "^5.1.31",

--- a/examples/remix/package.json
+++ b/examples/remix/package.json
@@ -10,10 +10,10 @@
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
   "dependencies": {
-    "@better-agent/client": "^0.0.1",
-    "@better-agent/core": "^0.0.1",
-    "@better-agent/plugins": "^0.0.1",
-    "@better-agent/providers": "^0.0.1",
+    "@better-agent/client": "workspace:*",
+    "@better-agent/core": "workspace:*",
+    "@better-agent/plugins": "workspace:*",
+    "@better-agent/providers": "workspace:*",
     "@remix-run/node": "^2.17.4",
     "@remix-run/react": "^2.17.4",
     "@remix-run/serve": "^2.17.4",

--- a/examples/solid/package.json
+++ b/examples/solid/package.json
@@ -10,10 +10,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@better-agent/client": "^0.0.1",
-    "@better-agent/core": "^0.0.1",
-    "@better-agent/plugins": "^0.0.1",
-    "@better-agent/providers": "^0.0.1",
+    "@better-agent/client": "workspace:*",
+    "@better-agent/core": "workspace:*",
+    "@better-agent/plugins": "workspace:*",
+    "@better-agent/providers": "workspace:*",
     "@solidjs/meta": "^0.29.4",
     "@solidjs/router": "^0.16.1",
     "@solidjs/start": "^1.3.2",

--- a/examples/svelte/package.json
+++ b/examples/svelte/package.json
@@ -12,10 +12,10 @@
     "typecheck": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json"
   },
   "dependencies": {
-    "@better-agent/client": "^0.0.1",
-    "@better-agent/core": "^0.0.1",
-    "@better-agent/plugins": "^0.0.1",
-    "@better-agent/providers": "^0.0.1",
+    "@better-agent/client": "workspace:*",
+    "@better-agent/core": "workspace:*",
+    "@better-agent/plugins": "workspace:*",
+    "@better-agent/providers": "workspace:*",
     "tailwindcss": "^4.1.18"
   },
   "devDependencies": {

--- a/examples/tanstack/package.json
+++ b/examples/tanstack/package.json
@@ -13,10 +13,10 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@better-agent/client": "^0.0.1",
-    "@better-agent/core": "^0.0.1",
-    "@better-agent/plugins": "^0.0.1",
-    "@better-agent/providers": "^0.0.1",
+    "@better-agent/client": "workspace:*",
+    "@better-agent/core": "workspace:*",
+    "@better-agent/plugins": "workspace:*",
+    "@better-agent/providers": "workspace:*",
     "@tailwindcss/vite": "^4.1.18",
     "@tanstack/react-devtools": "^0.7.0",
     "@tanstack/react-router": "1.168.10",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,6 @@
     "scripts": {
         "dev": "turbo dev --filter='./packages/*'",
         "build": "turbo build --filter='./packages/*'",
-        "docs:typecheck": "bunx tsc -p docs/tsconfig.json --noEmit",
-        "docs:og:preview": "cd docs && bun run og:preview",
         "lint": "biome check . --write",
         "lint:ci": "biome check .",
         "lint:types": "turbo run lint:types --filter='./packages/*'",

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
         "format": "biome format --write .",
         "clean": "turbo clean && rimraf \"node_modules\" \"**/node_modules\" \"**/dist\" \".turbo\"",
         "bump": "bumpp",
-        "release": "bun run build && bun run bump",
-        "release:canary": "bun run build && bumpp --preid canary --release prerelease"
+        "release": "bun run build && bun run bump --no-push",
+        "release:canary": "bun run build && bumpp --preid canary --release prerelease --no-push"
     },
     "devDependencies": {
         "@arethetypeswrong/cli": "^0.18.2",
@@ -29,7 +29,11 @@
         "turbo": "^2.6.0",
         "typescript": "5.6.3"
     },
-    "workspaces": ["packages/*", "examples/*", "docs"],
+    "workspaces": [
+        "packages/*",
+        "examples/*",
+        "docs"
+    ],
     "engines": {
         "node": ">=20",
         "bun": ">=1.3.3"

--- a/package.json
+++ b/package.json
@@ -29,11 +29,7 @@
         "turbo": "^2.6.0",
         "typescript": "5.6.3"
     },
-    "workspaces": [
-        "packages/*",
-        "examples/*",
-        "docs"
-    ],
+    "workspaces": ["packages/*", "examples/*", "docs"],
     "engines": {
         "node": ">=20",
         "bun": ">=1.3.3"

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/adapters",
-    "version": "0.1.0-canary.1",
+    "version": "0.1.0-canary.2",
     "description": "Better Agent framework adapters",
     "license": "MIT",
     "repository": {

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/adapters",
-    "version": "0.0.1",
+    "version": "0.1.0-canary.0",
     "description": "Better Agent framework adapters",
     "license": "MIT",
     "repository": {

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/adapters",
-    "version": "0.1.0-canary.0",
+    "version": "0.1.0-canary.1",
     "description": "Better Agent framework adapters",
     "license": "MIT",
     "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/cli",
-    "version": "0.1.0-canary.0",
+    "version": "0.1.0-canary.1",
     "description": "Better Agent CLI",
     "license": "MIT",
     "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/cli",
-    "version": "0.1.0-canary.1",
+    "version": "0.1.0-canary.2",
     "description": "Better Agent CLI",
     "license": "MIT",
     "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/cli",
-    "version": "0.0.1",
+    "version": "0.1.0-canary.0",
     "description": "Better Agent CLI",
     "license": "MIT",
     "repository": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/client",
-    "version": "0.0.1",
+    "version": "0.1.0-canary.0",
     "description": "Better Agent client TypeScript library",
     "license": "MIT",
     "repository": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/client",
-    "version": "0.1.0-canary.0",
+    "version": "0.1.0-canary.1",
     "description": "Better Agent client TypeScript library",
     "license": "MIT",
     "repository": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/client",
-    "version": "0.1.0-canary.1",
+    "version": "0.1.0-canary.2",
     "description": "Better Agent client TypeScript library",
     "license": "MIT",
     "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/core",
-    "version": "0.0.1",
+    "version": "0.1.0-canary.0",
     "description": "Better Agent core TypeScript library",
     "license": "MIT",
     "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/core",
-    "version": "0.1.0-canary.1",
+    "version": "0.1.0-canary.2",
     "description": "Better Agent core TypeScript library",
     "license": "MIT",
     "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/core",
-    "version": "0.1.0-canary.0",
+    "version": "0.1.0-canary.1",
     "description": "Better Agent core TypeScript library",
     "license": "MIT",
     "repository": {

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
     "name": "create-better-agent",
-    "version": "0.1.0-canary.1",
+    "version": "0.1.0-canary.2",
     "description": "Initialize Better Agent in an existing app",
     "license": "MIT",
     "type": "module",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
     "name": "create-better-agent",
-    "version": "0.0.1",
+    "version": "0.1.0-canary.0",
     "description": "Initialize Better Agent in an existing app",
     "license": "MIT",
     "type": "module",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
     "name": "create-better-agent",
-    "version": "0.1.0-canary.0",
+    "version": "0.1.0-canary.1",
     "description": "Initialize Better Agent in an existing app",
     "license": "MIT",
     "type": "module",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/plugins",
-    "version": "0.0.1",
+    "version": "0.1.0-canary.0",
     "description": "Better Agent plugins TypeScript library",
     "license": "MIT",
     "repository": {

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/plugins",
-    "version": "0.1.0-canary.1",
+    "version": "0.1.0-canary.2",
     "description": "Better Agent plugins TypeScript library",
     "license": "MIT",
     "repository": {

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/plugins",
-    "version": "0.1.0-canary.0",
+    "version": "0.1.0-canary.1",
     "description": "Better Agent plugins TypeScript library",
     "license": "MIT",
     "repository": {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/providers",
-    "version": "0.1.0-canary.0",
+    "version": "0.1.0-canary.1",
     "description": "Better Agent providers TypeScript library",
     "license": "MIT",
     "repository": {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/providers",
-    "version": "0.1.0-canary.1",
+    "version": "0.1.0-canary.2",
     "description": "Better Agent providers TypeScript library",
     "license": "MIT",
     "repository": {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/providers",
-    "version": "0.0.1",
+    "version": "0.1.0-canary.0",
     "description": "Better Agent providers TypeScript library",
     "license": "MIT",
     "repository": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/shared",
-    "version": "0.1.0-canary.1",
+    "version": "0.1.0-canary.2",
     "description": "Shared utilities for Better Agent",
     "license": "MIT",
     "repository": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/shared",
-    "version": "0.1.0-canary.0",
+    "version": "0.1.0-canary.1",
     "description": "Shared utilities for Better Agent",
     "license": "MIT",
     "repository": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/shared",
-    "version": "0.0.1",
+    "version": "0.1.0-canary.0",
     "description": "Shared utilities for Better Agent",
     "license": "MIT",
     "repository": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepare beta release by bumping all `@better-agent/*` packages to `0.1.0-canary.2` and switching examples to `workspace:*`. Also updates release scripts and optimizes the docs CTA image loading.

- **Dependencies**
  - Use `workspace:*` for `@better-agent/*` in all examples.
  - Bump package versions to `0.1.0-canary.2`.
  - Refresh lockfile.
  - Update release scripts to add `--no-push`; remove unused docs scripts.

- **Bug Fixes**
  - Eager-load `/cta-bg.png` in the docs CTA section.

<sup>Written for commit d7dca264e25094ea882923fe7b06c73cd37b0aa9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

