### PR TITLE
chore: add beta release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "clean": "turbo clean && rimraf \"node_modules\" \"**/node_modules\" \"**/dist\" \".turbo\"",
         "bump": "bumpp",
         "release": "bun run build && bun run bump --no-push",
+        "release:beta": "bun run build && bumpp --preid beta --release prerelease --no-push",
         "release:canary": "bun run build && bumpp --preid canary --release prerelease --no-push"
     },
     "devDependencies": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a `release:beta` script to create beta prereleases without pushing to git. It runs `bun` build, then bumps the version via `bumpp --preid beta --release prerelease --no-push`.

<sup>Written for commit e20c08a28f18607e4cc4b97cc115a4b89a0b4e0d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

