### PR TITLE
chore: sync main into canary

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -253,7 +253,7 @@
     },
     "packages/adapters": {
       "name": "@better-agent/adapters",
-      "version": "0.1.0-canary.2",
+      "version": "0.1.0-beta.1",
       "devDependencies": {
         "@better-agent/core": "workspace:*",
         "@types/bun": "^1.2.18",
@@ -269,7 +269,7 @@
     },
     "packages/cli": {
       "name": "@better-agent/cli",
-      "version": "0.1.0-canary.2",
+      "version": "0.1.0-beta.1",
       "bin": {
         "better-agent": "./dist/index.mjs",
       },
@@ -290,7 +290,7 @@
     },
     "packages/client": {
       "name": "@better-agent/client",
-      "version": "0.1.0-canary.2",
+      "version": "0.1.0-beta.1",
       "dependencies": {
         "@better-agent/core": "workspace:*",
         "@better-agent/shared": "workspace:*",
@@ -326,7 +326,7 @@
     },
     "packages/core": {
       "name": "@better-agent/core",
-      "version": "0.1.0-canary.2",
+      "version": "0.1.0-beta.1",
       "dependencies": {
         "@better-agent/shared": "workspace:*",
         "@standard-schema/spec": "1.1.0",
@@ -340,7 +340,7 @@
     },
     "packages/create": {
       "name": "create-better-agent",
-      "version": "0.1.0-canary.2",
+      "version": "0.1.0-beta.1",
       "bin": {
         "create-better-agent": "./dist/index.mjs",
       },
@@ -356,7 +356,7 @@
     },
     "packages/plugins": {
       "name": "@better-agent/plugins",
-      "version": "0.1.0-canary.2",
+      "version": "0.1.0-beta.1",
       "dependencies": {
         "@better-agent/shared": "workspace:*",
       },
@@ -370,7 +370,7 @@
     },
     "packages/providers": {
       "name": "@better-agent/providers",
-      "version": "0.1.0-canary.2",
+      "version": "0.1.0-beta.1",
       "dependencies": {
         "@better-agent/shared": "workspace:*",
         "zod": "^4.1.13",
@@ -385,7 +385,7 @@
     },
     "packages/shared": {
       "name": "@better-agent/shared",
-      "version": "0.1.0-canary.2",
+      "version": "0.1.0-beta.1",
       "dependencies": {
         "neverthrow": "^8.2.0",
       },

--- a/packages/adapters/package.json
+++ b/packages/adapters/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/adapters",
-    "version": "0.1.0-canary.2",
+    "version": "0.1.0-beta.1",
     "description": "Better Agent framework adapters",
     "license": "MIT",
     "repository": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/cli",
-    "version": "0.1.0-canary.2",
+    "version": "0.1.0-beta.1",
     "description": "Better Agent CLI",
     "license": "MIT",
     "repository": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/client",
-    "version": "0.1.0-canary.2",
+    "version": "0.1.0-beta.1",
     "description": "Better Agent client TypeScript library",
     "license": "MIT",
     "repository": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/core",
-    "version": "0.1.0-canary.2",
+    "version": "0.1.0-beta.1",
     "description": "Better Agent core TypeScript library",
     "license": "MIT",
     "repository": {

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
     "name": "create-better-agent",
-    "version": "0.1.0-canary.2",
+    "version": "0.1.0-beta.1",
     "description": "Initialize Better Agent in an existing app",
     "license": "MIT",
     "type": "module",

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/plugins",
-    "version": "0.1.0-canary.2",
+    "version": "0.1.0-beta.1",
     "description": "Better Agent plugins TypeScript library",
     "license": "MIT",
     "repository": {

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/providers",
-    "version": "0.1.0-canary.2",
+    "version": "0.1.0-beta.1",
     "description": "Better Agent providers TypeScript library",
     "license": "MIT",
     "repository": {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@better-agent/shared",
-    "version": "0.1.0-canary.2",
+    "version": "0.1.0-beta.1",
     "description": "Shared utilities for Better Agent",
     "license": "MIT",
     "repository": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Promote all packages to 0.1.0-beta.1 and update the lockfile to prepare the first beta release.

- **Dependencies**
  - Bumped versions to 0.1.0-beta.1 for `@better-agent/adapters`, `@better-agent/cli`, `@better-agent/client`, `@better-agent/core`, `create-better-agent`, `@better-agent/plugins`, `@better-agent/providers`, `@better-agent/shared`.
  - Regenerated `bun.lock` to reflect the new package versions.

<sup>Written for commit 1f7f53bbdb4e59fc306e6b3c9856bb992b62bf75. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

