### PR TITLE
chore: show only beta and stable releases in changelog

### DIFF
--- a/docs/lib/changelog.ts
+++ b/docs/lib/changelog.ts
@@ -24,6 +24,13 @@ function processBodyHtml(html: string): string {
     return processed;
 }
 
+function shouldIncludeRelease(tag: string, prerelease: boolean): boolean {
+    if (!prerelease) return true;
+
+    // TODO: remove beta prerelease support here once we have stable releases.
+    return /-beta(?:\.\d+)?$/i.test(tag);
+}
+
 export async function fetchReleases(): Promise<Release[]> {
     const releases: Release[] = [];
     let page = 1;
@@ -64,6 +71,7 @@ export async function fetchReleases(): Promise<Release[]> {
 
         for (const release of data) {
             if (release.draft) continue;
+            if (!shouldIncludeRelease(release.tag_name, release.prerelease)) continue;
 
             releases.push({
                 tag: release.tag_name,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
The changelog now shows only stable and `-beta` releases. We filter out drafts and any other prereleases (e.g., alpha, rc) when fetching releases.

<sup>Written for commit 882e23a162f8ccdd0e05198a0db86dc1fb50737f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

