### PR TITLE
fix: adjust ask ai max step handling

### DIFF
--- a/docs/lib/better-agent/server.ts
+++ b/docs/lib/better-agent/server.ts
@@ -18,7 +18,7 @@ const askDocs = defineAgent({
             title: z.string().optional(),
         })
         .optional(),
-    maxSteps: 4,
+    maxSteps: 10,
     instruction: (context) => `You are a friendly and helpful assistant for Better Agent.
 ${context?.url ? `\nThe user is currently viewing the page: ${context.title ? `${context.title} (${context.url})` : context.url}. Prioritize this context if relevant.\n` : ""}
 Your goal is to provide very short, straight-to-the-point answers based only on the Better Agent documentation.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increases `maxSteps` for the docs Ask agent from 4 to 10 to prevent early termination and allow deeper reasoning. Improves answer completeness for longer, multi-step questions.

<sup>Written for commit 374c36470d85d46046e9f6e1143d339159b841c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

