### PR TITLE
fix: ask ai steps and clean changelog releases

### DIFF
--- a/docs/lib/better-agent/server.ts
+++ b/docs/lib/better-agent/server.ts
@@ -18,7 +18,7 @@ const askDocs = defineAgent({
             title: z.string().optional(),
         })
         .optional(),
-    maxSteps: 4,
+    maxSteps: 10,
     instruction: (context) => `You are a friendly and helpful assistant for Better Agent.
 ${context?.url ? `\nThe user is currently viewing the page: ${context.title ? `${context.title} (${context.url})` : context.url}. Prioritize this context if relevant.\n` : ""}
 Your goal is to provide very short, straight-to-the-point answers based only on the Better Agent documentation.

--- a/docs/lib/changelog.ts
+++ b/docs/lib/changelog.ts
@@ -24,6 +24,13 @@ function processBodyHtml(html: string): string {
     return processed;
 }
 
+function shouldIncludeRelease(tag: string, prerelease: boolean): boolean {
+    if (!prerelease) return true;
+
+    // TODO: remove beta prerelease support here once we have stable releases.
+    return /-beta(?:\.\d+)?$/i.test(tag);
+}
+
 export async function fetchReleases(): Promise<Release[]> {
     const releases: Release[] = [];
     let page = 1;
@@ -64,6 +71,7 @@ export async function fetchReleases(): Promise<Release[]> {
 
         for (const release of data) {
             if (release.draft) continue;
+            if (!shouldIncludeRelease(release.tag_name, release.prerelease)) continue;
 
             releases.push({
                 tag: release.tag_name,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase the Better Agent docs assistant max steps from 4 to 10 for more complete answers. Limit the changelog to stable and -beta releases to keep it focused.

<sup>Written for commit 2814024c4049c5c189cecc331014acadad9472ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

