### PR TITLE
fix(client): treat tool-call results as results in conversation items

### DIFF
--- a/packages/client/__tests__/client.test.ts
+++ b/packages/client/__tests__/client.test.ts
@@ -523,6 +523,64 @@ describe("client transport", () => {
         assert.deepEqual(hydrated, stripToolTarget(liveState.messages));
     });
 
+    test("fromConversationItems treats tool-call results with optional arguments as results", () => {
+        const hydrated = fromConversationItems([
+            {
+                type: "message",
+                role: "assistant",
+                content: "Checking weather...",
+            },
+            {
+                type: "tool-call",
+                callId: "call_1",
+                name: "get_weather",
+                arguments: '{"location":"Addis Ababa","unit":"Celsius"}',
+            },
+            {
+                type: "tool-call",
+                callId: "call_1",
+                name: "get_weather",
+                arguments: '{"location":"Addis Ababa","unit":"Celsius"}',
+                result: {
+                    type: "tool_error",
+                    message: "fetch failed",
+                },
+                isError: true,
+            },
+        ]);
+
+        assert.deepEqual(hydrated, [
+            {
+                localId: hydrated[0]?.localId,
+                role: "assistant",
+                parts: [
+                    {
+                        type: "text",
+                        text: "Checking weather...",
+                        state: "complete",
+                    },
+                    {
+                        type: "tool-call",
+                        callId: "call_1",
+                        name: "get_weather",
+                        args: '{"location":"Addis Ababa","unit":"Celsius"}',
+                        status: "error",
+                        state: "completed",
+                    },
+                    {
+                        type: "tool-result",
+                        callId: "call_1",
+                        result: {
+                            type: "tool_error",
+                            message: "fetch failed",
+                        },
+                        status: "error",
+                    },
+                ],
+            },
+        ]);
+    });
+
     test("getMessagesFromResponse synthesizes completed tool calls for standalone provider tool results", () => {
         const messages = getMessagesFromResponse({
             output: [

--- a/packages/client/src/core/utils.ts
+++ b/packages/client/src/core/utils.ts
@@ -2,6 +2,8 @@ import type {
     ConversationItem,
     GenerativeModelInputItem,
     GenerativeModelInputMessagePart,
+    GenerativeModelProviderToolResult,
+    GenerativeModelToolCallResult,
 } from "@better-agent/core/providers";
 import type { UIMessage, UIMessagePart } from "../types/ui";
 
@@ -384,6 +386,12 @@ const contentToUIParts = (content: string | unknown[]): UIMessagePart[] => {
         .filter((part): part is UIMessagePart => part !== null);
 };
 
+const isToolResultConversationItem = (
+    item: ConversationItem,
+): item is GenerativeModelToolCallResult | GenerativeModelProviderToolResult =>
+    item.type === "provider-tool-result" ||
+    (item.type === "tool-call" && Object.prototype.hasOwnProperty.call(item, "result"));
+
 /** Converts model input messages back into UI messages. */
 export const fromModelMessages = (
     messages: GenerativeModelInputItem[],
@@ -476,7 +484,7 @@ export const fromConversationItems = (
             continue;
         }
 
-        if ("arguments" in item) {
+        if (item.type === "tool-call" && !isToolResultConversationItem(item)) {
             const part: UIMessagePart = {
                 type: "tool-call",
                 callId: item.callId,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes conversation hydration in `packages/client` so tool-call items with a `result` are treated as tool results, not tool-call parts. This ensures correct UI rendering and error status for tool outputs.

- **Bug Fixes**
  - Added `isToolResultConversationItem` to detect `provider-tool-result` and `tool-call` items that include `result`.
  - Updated `fromConversationItems` to create a `tool-result` part for these items instead of a `tool-call` part.
  - Added a test for a tool call with arguments and an error result to validate part types and statuses.

<sup>Written for commit 0b963854de558faf47f0ed53f4e316175ba3ede1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

