### PR TITLE
fix: typo in code demo

### DIFF
--- a/docs/app/_components/code-demo.tsx
+++ b/docs/app/_components/code-demo.tsx
@@ -56,7 +56,7 @@ const leftTokens: (Tok | null)[] = [
     null,
     { t: "  instruction", c: PR },
     { t: ": ", c: X },
-    { t: '"You are a helpful"', c: S },
+    { t: '"You are helpful"', c: S },
     { t: ",", c: X },
     null,
     { t: "});", c: X },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a grammar typo in the docs code demo by changing the instruction string from "You are a helpful" to "You are helpful" for clarity.

<sup>Written for commit 560ae03ea6cd5f2a6e1d2fa1c419a3a59e07bbbf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

