### PR TITLE
fix(core): move tool request lifecycle ownership to providers

### DIFF
--- a/packages/core/__tests__/integration/tool-execution.test.ts
+++ b/packages/core/__tests__/integration/tool-execution.test.ts
@@ -68,39 +68,40 @@ const providerToolLifecycleEvents = (params: {
     runId?: string;
     agentName?: string;
     toolTarget?: "server" | "client" | "hosted";
-}) => [
-    {
-        type: Events.TOOL_CALL_START,
-        parentMessageId: params.messageId,
-        toolCallId: params.toolCallId,
-        toolCallName: params.toolCallName,
-        runId: params.runId ?? "",
-        agentName: params.agentName ?? "",
-        toolTarget: params.toolTarget ?? "server",
-        timestamp: Date.now(),
-    },
-    {
-        type: Events.TOOL_CALL_ARGS,
-        parentMessageId: params.messageId,
-        toolCallId: params.toolCallId,
-        toolCallName: params.toolCallName,
-        delta: params.args,
-        runId: params.runId ?? "",
-        agentName: params.agentName ?? "",
-        toolTarget: params.toolTarget ?? "server",
-        timestamp: Date.now(),
-    },
-    {
-        type: Events.TOOL_CALL_END,
-        parentMessageId: params.messageId,
-        toolCallId: params.toolCallId,
-        toolCallName: params.toolCallName,
-        runId: params.runId ?? "",
-        agentName: params.agentName ?? "",
-        toolTarget: params.toolTarget ?? "server",
-        timestamp: Date.now(),
-    },
-] satisfies Event[];
+}) =>
+    [
+        {
+            type: Events.TOOL_CALL_START,
+            parentMessageId: params.messageId,
+            toolCallId: params.toolCallId,
+            toolCallName: params.toolCallName,
+            runId: params.runId ?? "",
+            agentName: params.agentName ?? "",
+            toolTarget: params.toolTarget ?? "server",
+            timestamp: Date.now(),
+        },
+        {
+            type: Events.TOOL_CALL_ARGS,
+            parentMessageId: params.messageId,
+            toolCallId: params.toolCallId,
+            toolCallName: params.toolCallName,
+            delta: params.args,
+            runId: params.runId ?? "",
+            agentName: params.agentName ?? "",
+            toolTarget: params.toolTarget ?? "server",
+            timestamp: Date.now(),
+        },
+        {
+            type: Events.TOOL_CALL_END,
+            parentMessageId: params.messageId,
+            toolCallId: params.toolCallId,
+            toolCallName: params.toolCallName,
+            runId: params.runId ?? "",
+            agentName: params.agentName ?? "",
+            toolTarget: params.toolTarget ?? "server",
+            timestamp: Date.now(),
+        },
+    ] satisfies Event[];
 
 describe("tool execution", () => {
     test("run reuses provider-emitted assistant message id for tool parent linkage", async () => {

--- a/packages/core/__tests__/integration/tool-execution.test.ts
+++ b/packages/core/__tests__/integration/tool-execution.test.ts
@@ -77,7 +77,7 @@ const providerToolLifecycleEvents = (params: {
             toolCallName: params.toolCallName,
             runId: params.runId ?? "",
             agentName: params.agentName ?? "",
-            toolTarget: params.toolTarget ?? "server",
+            toolTarget: params.toolTarget ?? "hosted",
             timestamp: Date.now(),
         },
         {
@@ -88,7 +88,7 @@ const providerToolLifecycleEvents = (params: {
             delta: params.args,
             runId: params.runId ?? "",
             agentName: params.agentName ?? "",
-            toolTarget: params.toolTarget ?? "server",
+            toolTarget: params.toolTarget ?? "hosted",
             timestamp: Date.now(),
         },
         {
@@ -98,7 +98,7 @@ const providerToolLifecycleEvents = (params: {
             toolCallName: params.toolCallName,
             runId: params.runId ?? "",
             agentName: params.agentName ?? "",
-            toolTarget: params.toolTarget ?? "server",
+            toolTarget: params.toolTarget ?? "hosted",
             timestamp: Date.now(),
         },
     ] satisfies Event[];
@@ -176,6 +176,9 @@ describe("tool execution", () => {
         expect(
             assistantStart && "messageId" in assistantStart ? assistantStart.messageId : undefined,
         ).toBe(toolStart && "parentMessageId" in toolStart ? toolStart.parentMessageId : undefined);
+        expect(toolStart && "toolTarget" in toolStart ? toolStart.toolTarget : undefined).toBe(
+            "server",
+        );
     });
 
     test("stream reuses provider-emitted assistant message id for tool parent linkage", async () => {
@@ -259,6 +262,9 @@ describe("tool execution", () => {
         expect(
             assistantStart && "messageId" in assistantStart ? assistantStart.messageId : undefined,
         ).toBe(toolStart && "parentMessageId" in toolStart ? toolStart.parentMessageId : undefined);
+        expect(toolStart && "toolTarget" in toolStart ? toolStart.toolTarget : undefined).toBe(
+            "server",
+        );
     });
 
     test("server tool executes and result is fed back into the next model step", async () => {
@@ -407,6 +413,9 @@ describe("tool execution", () => {
             Events.TOOL_CALL_ARGS,
             Events.TOOL_CALL_END,
         ]);
+        expect(
+            toolEvents.every((event) => "toolTarget" in event && event.toolTarget === "client"),
+        ).toBeTrue();
 
         const runStarted = seenEvents.find((event) => event.type === Events.RUN_STARTED);
         const runId = runStarted && "runId" in runStarted ? runStarted.runId : "";
@@ -566,6 +575,16 @@ describe("tool execution", () => {
             Events.TOOL_APPROVAL_REQUIRED,
             Events.TOOL_APPROVAL_UPDATED,
         ]);
+        expect(
+            toolEvents
+                .filter(
+                    (event) =>
+                        event.type === Events.TOOL_CALL_START ||
+                        event.type === Events.TOOL_CALL_ARGS ||
+                        event.type === Events.TOOL_CALL_END,
+                )
+                .every((event) => "toolTarget" in event && event.toolTarget === "client"),
+        ).toBeTrue();
         expect(toolEvents[4]).toMatchObject({
             type: Events.TOOL_APPROVAL_UPDATED,
             state: "requested",

--- a/packages/core/__tests__/integration/tool-execution.test.ts
+++ b/packages/core/__tests__/integration/tool-execution.test.ts
@@ -60,6 +60,48 @@ const isHilClientToolEvent = (event: Event) =>
     event.type === Events.TOOL_APPROVAL_UPDATED ||
     event.type === Events.TOOL_CALL_END;
 
+const providerToolLifecycleEvents = (params: {
+    messageId: string;
+    toolCallId: string;
+    toolCallName: string;
+    args: string;
+    runId?: string;
+    agentName?: string;
+    toolTarget?: "server" | "client" | "hosted";
+}) => [
+    {
+        type: Events.TOOL_CALL_START,
+        parentMessageId: params.messageId,
+        toolCallId: params.toolCallId,
+        toolCallName: params.toolCallName,
+        runId: params.runId ?? "",
+        agentName: params.agentName ?? "",
+        toolTarget: params.toolTarget ?? "server",
+        timestamp: Date.now(),
+    },
+    {
+        type: Events.TOOL_CALL_ARGS,
+        parentMessageId: params.messageId,
+        toolCallId: params.toolCallId,
+        toolCallName: params.toolCallName,
+        delta: params.args,
+        runId: params.runId ?? "",
+        agentName: params.agentName ?? "",
+        toolTarget: params.toolTarget ?? "server",
+        timestamp: Date.now(),
+    },
+    {
+        type: Events.TOOL_CALL_END,
+        parentMessageId: params.messageId,
+        toolCallId: params.toolCallId,
+        toolCallName: params.toolCallName,
+        runId: params.runId ?? "",
+        agentName: params.agentName ?? "",
+        toolTarget: params.toolTarget ?? "server",
+        timestamp: Date.now(),
+    },
+] satisfies Event[];
+
 describe("tool execution", () => {
     test("run reuses provider-emitted assistant message id for tool parent linkage", async () => {
         const tool = defineTool({
@@ -101,6 +143,12 @@ describe("tool execution", () => {
                                     messageId,
                                     timestamp: Date.now(),
                                 },
+                                ...providerToolLifecycleEvents({
+                                    messageId,
+                                    toolCallId: "call_1",
+                                    toolCallName: "lookup",
+                                    args: "{}",
+                                }),
                             ],
                         });
                     }
@@ -166,6 +214,14 @@ describe("tool execution", () => {
                                     messageId,
                                     timestamp: Date.now(),
                                 });
+                                for (const event of providerToolLifecycleEvents({
+                                    messageId,
+                                    toolCallId: "call_1",
+                                    toolCallName: "lookup",
+                                    args: "{}",
+                                })) {
+                                    yield ok(event);
+                                }
                             })(),
                             final: Promise.resolve(
                                 createToolCallResponse([
@@ -289,10 +345,25 @@ describe("tool execution", () => {
         const agent = createTextAgent({
             model: {
                 ...createTextAgent().model,
-                async doGenerateStream() {
+                async doGenerateStream(_options: unknown, ctx: { generateMessageId(): string }) {
                     const response = responses.shift() ?? createTextResponse("done");
+                    const messageId = ctx.generateMessageId();
                     return ok({
-                        events: (async function* () {})(),
+                        events: (async function* () {
+                            if (
+                                response.output[0]?.type === "tool-call" &&
+                                "arguments" in response.output[0]
+                            ) {
+                                for (const event of providerToolLifecycleEvents({
+                                    messageId,
+                                    toolCallId: response.output[0].callId,
+                                    toolCallName: response.output[0].name,
+                                    args: response.output[0].arguments,
+                                })) {
+                                    yield ok(event);
+                                }
+                            }
+                        })(),
                         final: Promise.resolve(response),
                     });
                 },
@@ -356,9 +427,19 @@ describe("tool execution", () => {
         const agent = createTextAgent({
             model: {
                 ...createTextAgent().model,
-                async doGenerateStream() {
+                async doGenerateStream(_options: unknown, ctx: { generateMessageId(): string }) {
+                    const messageId = ctx.generateMessageId();
                     return ok({
-                        events: (async function* () {})(),
+                        events: (async function* () {
+                            for (const event of providerToolLifecycleEvents({
+                                messageId,
+                                toolCallId: "call_1",
+                                toolCallName: "confirm",
+                                args: '{"ok":true}',
+                            })) {
+                                yield ok(event);
+                            }
+                        })(),
                         final: Promise.resolve(
                             createToolCallResponse([
                                 { callId: "call_1", name: "confirm", arguments: '{"ok":true}' },
@@ -415,10 +496,25 @@ describe("tool execution", () => {
         const agent = createTextAgent({
             model: {
                 ...createTextAgent().model,
-                async doGenerateStream() {
+                async doGenerateStream(_options: unknown, ctx: { generateMessageId(): string }) {
                     const response = responses.shift() ?? createTextResponse("done");
+                    const messageId = ctx.generateMessageId();
                     return ok({
-                        events: (async function* () {})(),
+                        events: (async function* () {
+                            if (
+                                response.output[0]?.type === "tool-call" &&
+                                "arguments" in response.output[0]
+                            ) {
+                                for (const event of providerToolLifecycleEvents({
+                                    messageId,
+                                    toolCallId: response.output[0].callId,
+                                    toolCallName: response.output[0].name,
+                                    args: response.output[0].arguments,
+                                })) {
+                                    yield ok(event);
+                                }
+                            }
+                        })(),
                         final: Promise.resolve(response),
                     });
                 },
@@ -465,11 +561,11 @@ describe("tool execution", () => {
         expect(toolEvents.map((event) => event.type)).toEqual([
             Events.TOOL_CALL_START,
             Events.TOOL_CALL_ARGS,
+            Events.TOOL_CALL_END,
             Events.TOOL_APPROVAL_REQUIRED,
             Events.TOOL_APPROVAL_UPDATED,
-            Events.TOOL_CALL_END,
         ]);
-        expect(toolEvents[3]).toMatchObject({
+        expect(toolEvents[4]).toMatchObject({
             type: Events.TOOL_APPROVAL_UPDATED,
             state: "requested",
         });

--- a/packages/core/src/run/execute-tool-calls.ts
+++ b/packages/core/src/run/execute-tool-calls.ts
@@ -49,7 +49,6 @@ type PreparedToolCall = {
     skipResult?: unknown;
     parseError?: BetterAgentError;
     validationError?: BetterAgentError;
-    shouldEmitToolCallEnd: boolean;
 };
 
 const getToolRunName = (tool: AgentToolDefinition): string | undefined =>
@@ -180,55 +179,6 @@ export const executeToolCalls = async <TContext>(params: {
                 args.retryable ??
                 (args.error instanceof BetterAgentError ? args.error.retryable : undefined),
         });
-
-    const emitToolCallStart = async (prepared: {
-        toolCall: GenerativeModelToolCallRequest;
-        toolTarget: "server" | "client";
-    }) => {
-        await params.emit({
-            type: Events.TOOL_CALL_START,
-            runId: params.runId,
-            agentName: params.agentName,
-            parentMessageId: params.parentMessageId,
-            toolCallId: prepared.toolCall.callId,
-            toolCallName: prepared.toolCall.name,
-            toolTarget: prepared.toolTarget,
-            timestamp: Date.now(),
-        });
-    };
-
-    const emitToolCallArgs = async (prepared: {
-        toolCall: GenerativeModelToolCallRequest;
-        toolTarget: "server" | "client";
-    }) => {
-        await params.emit({
-            type: Events.TOOL_CALL_ARGS,
-            runId: params.runId,
-            agentName: params.agentName,
-            parentMessageId: params.parentMessageId,
-            toolCallId: prepared.toolCall.callId,
-            toolCallName: prepared.toolCall.name,
-            delta: prepared.toolCall.arguments,
-            toolTarget: prepared.toolTarget,
-            timestamp: Date.now(),
-        });
-    };
-
-    const emitToolCallEnd = async (prepared: {
-        toolCall: GenerativeModelToolCallRequest;
-        toolTarget: "server" | "client";
-    }) => {
-        await params.emit({
-            type: Events.TOOL_CALL_END,
-            runId: params.runId,
-            agentName: params.agentName,
-            parentMessageId: params.parentMessageId,
-            toolCallId: prepared.toolCall.callId,
-            toolCallName: prepared.toolCall.name,
-            toolTarget: prepared.toolTarget,
-            timestamp: Date.now(),
-        });
-    };
 
     const emitToolCallResult = async (
         prepared: PreparedToolCall,
@@ -722,7 +672,6 @@ export const executeToolCalls = async <TContext>(params: {
                     toolTarget,
                 }),
                 skip: false,
-                shouldEmitToolCallEnd: false,
             };
 
             return await executeApprovedInput(prepared, validatedInput.value, recoveryDepth);
@@ -736,7 +685,6 @@ export const executeToolCalls = async <TContext>(params: {
                     tool,
                     toolTarget,
                     skip: false,
-                    shouldEmitToolCallEnd: false,
                     parseError: BetterAgentError.wrap({
                         err: parsed.error,
                         message: `Failed to parse arguments for tool '${toolCall.name}'`,
@@ -772,7 +720,6 @@ export const executeToolCalls = async <TContext>(params: {
                     args: beforeHook.args,
                     skip: true,
                     skipResult: beforeHook.decision.result,
-                    shouldEmitToolCallEnd: true,
                 };
             }
 
@@ -784,7 +731,6 @@ export const executeToolCalls = async <TContext>(params: {
                     toolTarget,
                     args: beforeHook.args,
                     skip: false,
-                    shouldEmitToolCallEnd: false,
                     validationError: validatedInput.error.at({
                         at: "core.run.executeToolCalls.validateToolInput",
                     }),
@@ -805,7 +751,6 @@ export const executeToolCalls = async <TContext>(params: {
                     toolTarget,
                 }),
                 skip: false,
-                shouldEmitToolCallEnd: true,
             };
 
             if (prepared.resolvedApproval?.required) {
@@ -874,13 +819,7 @@ export const executeToolCalls = async <TContext>(params: {
             };
         };
 
-        await emitToolCallStart({ toolCall, toolTarget });
-        await emitToolCallArgs({ toolCall, toolTarget });
-
         const prepared = await prepareToolCall();
-        if (prepared.shouldEmitToolCallEnd) {
-            await emitToolCallEnd(prepared);
-        }
 
         const outcome = await executePreparedTool(prepared);
         const finalOutcome = await applyAfterToolCall(prepared, outcome);

--- a/packages/core/src/run/helpers.ts
+++ b/packages/core/src/run/helpers.ts
@@ -913,7 +913,7 @@ export async function saveConversationMessages(params: {
     conversations?: ConversationStore;
     conversationId?: string;
     agentName?: string;
-    result: RunResult & { items: ConversationItem[] };
+    result: { items: ConversationItem[] };
     loaded?: LoadedConversation;
 }): Promise<void> {
     if (!params.conversations || params.conversationId === undefined) {

--- a/packages/core/src/run/model-strategy.ts
+++ b/packages/core/src/run/model-strategy.ts
@@ -1,5 +1,6 @@
 import { BetterAgentError } from "@better-agent/shared/errors";
 import type { Event } from "../events";
+import type { AgentToolDefinition, ToolTarget } from "../tools";
 import type { ModelCallStrategy } from "./types";
 
 const getAssistantMessageIdFromEvent = (event: Event): string | undefined => {
@@ -22,6 +23,51 @@ const getAssistantMessageIdFromEvent = (event: Event): string | undefined => {
     }
 
     return undefined;
+};
+
+const resolveToolTarget = (
+    tools: AgentToolDefinition[],
+    toolCallName: string,
+): ToolTarget | undefined => {
+    const tool = tools.find((candidate) => {
+        if (candidate.kind === "hosted") {
+            return candidate.name === toolCallName || candidate.type === toolCallName;
+        }
+
+        return candidate.name === toolCallName;
+    });
+
+    if (!tool) {
+        return undefined;
+    }
+
+    return tool.kind;
+};
+
+const enrichToolEvent = (
+    event: Event,
+    params: {
+        runId: string;
+        agentName: string;
+        tools: AgentToolDefinition[];
+    },
+): Event => {
+    switch (event.type) {
+        case "TOOL_CALL_START":
+        case "TOOL_CALL_ARGS":
+        case "TOOL_CALL_END":
+        case "TOOL_CALL_RESULT": {
+            const toolTarget = resolveToolTarget(params.tools, event.toolCallName);
+            return {
+                ...event,
+                runId: params.runId,
+                agentName: params.agentName,
+                ...(toolTarget !== undefined ? { toolTarget } : {}),
+            };
+        }
+        default:
+            return event;
+    }
 };
 
 export const createRunModelCallStrategy = <TContext>(): ModelCallStrategy<TContext> => ({
@@ -77,9 +123,15 @@ export const createRunModelCallStrategy = <TContext>(): ModelCallStrategy<TConte
 
         const { response, events } = responseResult.value;
         for (const event of events ?? []) {
-            assistantMessageId = getAssistantMessageIdFromEvent(event) ?? assistantMessageId;
+            const enrichedEvent = enrichToolEvent(event, {
+                runId: params.runId,
+                agentName: params.agentName,
+                tools: params.tools,
+            });
+            assistantMessageId =
+                getAssistantMessageIdFromEvent(enrichedEvent) ?? assistantMessageId;
             await options.emit({
-                ...event,
+                ...enrichedEvent,
             });
         }
 
@@ -149,10 +201,15 @@ export const createStreamModelCallStrategy = <TContext>(): ModelCallStrategy<TCo
                 throw eventResult.error;
             }
 
+            const enrichedEvent = enrichToolEvent(eventResult.value, {
+                runId: params.runId,
+                agentName: params.agentName,
+                tools: params.tools,
+            });
             assistantMessageId =
-                getAssistantMessageIdFromEvent(eventResult.value) ?? assistantMessageId;
+                getAssistantMessageIdFromEvent(enrichedEvent) ?? assistantMessageId;
             await options.emit({
-                ...eventResult.value,
+                ...enrichedEvent,
             });
         }
 

--- a/packages/core/src/run/runtime.ts
+++ b/packages/core/src/run/runtime.ts
@@ -314,7 +314,7 @@ export function createRuntime<const TAgents extends readonly AnyAgentDefinition[
         if (params.saveConversationParams) {
             await saveConversationMessages({
                 ...params.saveConversationParams,
-                result: { ...params.result, items: itemsToSave },
+                result: { items: itemsToSave },
             });
         }
 
@@ -533,7 +533,7 @@ export function createRuntime<const TAgents extends readonly AnyAgentDefinition[
             } finally {
                 execution.cleanupSignal();
             }
-        }) as unknown as BetterAgentRuntime<TAgents>["run"],
+        }) as BetterAgentRuntime<TAgents>["run"],
 
         stream: (<TContext, TOutput extends OutputSchemaDefinition | undefined = undefined>(
             agent: TAgents[number]["name"],
@@ -709,7 +709,7 @@ export function createRuntime<const TAgents extends readonly AnyAgentDefinition[
                 events: queue.iterate(),
                 result,
             };
-        }) as unknown as BetterAgentRuntime<TAgents>["stream"],
+        }) as BetterAgentRuntime<TAgents>["stream"],
 
         loadConversation: async <TName extends TAgents[number]["name"]>(
             agent: TName,


### PR DESCRIPTION



<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved tool call lifecycle to providers, added runtime enrichment of provider events with `runId`, `agentName`, and inferred `toolTarget`, and narrowed `saveConversationMessages` inputs for simpler types.

- **Refactors**
  - Removed lifecycle event emission from `execute-tool-calls.ts` (deleted emit helpers and `shouldEmitToolCallEnd`).
  - Enriched provider `TOOL_CALL_*`/`TOOL_CALL_RESULT` events with `runId`, `agentName`, and `toolTarget` inferred from declared tools; applies to both run and stream paths.
  - Narrowed `saveConversationMessages` to accept `result: { items }`; updated runtime usage and cleaned up casts.
  - Updated integration tests to emit provider events via `providerToolLifecycleEvents` and use `ctx.generateMessageId()`; event order now `START` → `ARGS` → `END` → approval events (`TOOL_APPROVAL_REQUIRED`, `TOOL_APPROVAL_UPDATED`).

- **Migration**
  - Ensure your model/provider emits lifecycle events tied to `ctx.generateMessageId()`.
  - Do not rely on the runtime to emit `TOOL_CALL_*` events; expect `TOOL_CALL_END` before approval events.
  - If you call `saveConversationMessages` directly, pass `result: { items }` instead of a `RunResult`.

<sup>Written for commit 98fe3416e16493f3c44cb8157042ecee60b58504. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



