### PR TITLE
fix(core): make single_turn_only keep only latest history and cleanup

### DIFF
--- a/packages/core/__tests__/unit/conversation-history.test.ts
+++ b/packages/core/__tests__/unit/conversation-history.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { createMemoryConversationStore } from "../../src/persistence";
 import { loadConversationMessages } from "../../src/run/helpers";
 import { createRuntime } from "../../src/run/runtime";
-import { createTextAgent } from "../helpers/mock-model";
+import { createScriptedModel, createTextAgent } from "../helpers/mock-model";
 
 describe("conversation history helpers", () => {
     test("loadConversationMessages skips prepending stored history when replaceHistory is true", async () => {
@@ -147,6 +147,71 @@ describe("conversation history helpers", () => {
             { type: "message", role: "system", content: "prepared" },
             { type: "message", role: "user", content: "fresh" },
         ]);
+    });
+
+    test("loadConversationMessages keeps only the latest turn for single_turn_only", async () => {
+        const conversations = createMemoryConversationStore();
+        await conversations.save({
+            conversationId: "conv_1",
+            agentName: "assistant",
+            items: [{ type: "message", role: "user", content: "stored" }],
+        });
+
+        const loaded = await loadConversationMessages({
+            conversations,
+            conversationId: "conv_1",
+            agentName: "assistant",
+            input: [{ type: "message", role: "user", content: "fresh" }],
+            caps: {
+                inputShape: "chat",
+                replayMode: "single_turn_only",
+                inputModalities: { text: true },
+                outputModalities: { text: true },
+            },
+        });
+
+        expect(loaded.input).toEqual([{ type: "message", role: "user", content: "fresh" }]);
+        expect(loaded.items).toEqual([{ type: "message", role: "user", content: "fresh" }]);
+        expect(loaded.replayStartIndex).toBe(0);
+        expect(loaded.conversationReplayActive).toBe(false);
+    });
+
+    test("runtime single_turn_only overwrites stored history with the latest turn", async () => {
+        const conversations = createMemoryConversationStore();
+        const agent = createTextAgent({
+            model: createScriptedModel([{ output: [], finishReason: "stop", usage: {} }]),
+        });
+        agent.model.caps.replayMode = "single_turn_only";
+
+        const runtime = createRuntime({
+            agents: [agent] as const,
+            conversations,
+        });
+
+        await runtime.run("assistant", {
+            input: "first" as never,
+            conversationId: "conv_1",
+        });
+
+        expect(
+            await conversations.load({ conversationId: "conv_1", agentName: "assistant" }),
+        ).toMatchObject({
+            items: [{ type: "message", role: "user", content: "first" }],
+        });
+
+        await runtime.run("assistant", {
+            input: "second" as never,
+            conversationId: "conv_1",
+        });
+
+        expect(
+            await conversations.load({ conversationId: "conv_1", agentName: "assistant" }),
+        ).toMatchObject({
+            items: [
+                { type: "message", role: "user", content: "second" },
+                { type: "message", role: "assistant", content: "done" },
+            ],
+        });
     });
 
     test("createMemoryConversationStore enforces cursor checks", async () => {

--- a/packages/core/src/run/agent-loop.ts
+++ b/packages/core/src/run/agent-loop.ts
@@ -83,7 +83,7 @@ export const runAgentLoop = async <TContext>(
         context: options.context,
     };
 
-    const instructionField = "instruction" in options.agent ? options.agent.instruction : undefined;
+    const instructionField = options.agent.instruction;
     const instructionResolver = instructionField as ((context: TContext) => string) | undefined;
     const instruction =
         typeof instructionResolver === "function"
@@ -179,9 +179,7 @@ export const runAgentLoop = async <TContext>(
                               ),
                           );
 
-                const effectiveInstruction = (prepared.systemInstruction ?? instruction) as
-                    | GenerativeModelInputMessageContent<typeof modelCaps>
-                    | undefined;
+                const effectiveInstruction = prepared.systemInstruction ?? instruction;
                 assertInstructionSupported(
                     effectiveInstruction,
                     `${traceBase}.prepareModelInput.validateInstruction`,

--- a/packages/core/src/run/helpers.ts
+++ b/packages/core/src/run/helpers.ts
@@ -33,15 +33,14 @@ import type { OnOutputError, OutputErrorContext, OutputErrorMode } from "./outpu
 import type { ContextBoundAgent, ConversationReplayOptions, RunOptions, RunResult } from "./types";
 
 const MAX_OUTPUT_REPAIR_DEPTH = 2;
-type NonTextInputModality = Exclude<Modality, "text">;
-
-const isJsonSchemaRecord = (value: unknown): value is Record<string, unknown> =>
-    typeof value === "object" && value !== null && !Array.isArray(value);
 
 const normalizeStructuredOutputJsonSchema = (
     schema: Record<string, unknown>,
 ): Record<string, unknown> => {
     const normalized: Record<string, unknown> = {};
+
+    const isJsonSchemaRecord = (value: unknown): value is Record<string, unknown> =>
+        typeof value === "object" && value !== null && !Array.isArray(value);
 
     for (const [key, value] of Object.entries(schema)) {
         if (Array.isArray(value)) {
@@ -86,14 +85,8 @@ export function createStreamPersistenceEmitter(params: {
             seq: nextSeq++,
             timestamp: event.timestamp ?? Date.now(),
         };
-        try {
-            await stream.append(params.streamId, streamEvent);
-        } catch (error) {
-            if (error instanceof Error && error.message.includes("not found")) {
-                return;
-            }
-            throw error;
-        }
+
+        await stream.append(params.streamId, streamEvent);
     };
 }
 
@@ -302,7 +295,7 @@ const validateMessageContentCapabilities = (params: {
             partType === "file" ||
             partType === "embedding"
         ) {
-            const modality = partType as NonTextInputModality;
+            const modality = partType as Exclude<Modality, "text">;
             if (caps.inputModalities?.[modality] !== true) {
                 throwUnsupportedInputModality({
                     agent: params.agent,
@@ -879,7 +872,17 @@ export async function loadConversationMessages(params: {
     const replayMode =
         caps.replayMode ?? (caps.inputShape === "prompt" ? "single_turn_persistent" : "multi_turn");
 
-    if (replayMode !== "multi_turn") {
+    if (replayMode === "single_turn_only") {
+        return {
+            input: params.input,
+            items: durableInputItems,
+            replayStartIndex: 0,
+            conversationReplayActive: false,
+            loaded,
+        };
+    }
+
+    if (replayMode === "single_turn_persistent") {
         return {
             input: params.input,
             items: [...loaded.items, ...durableInputItems],
@@ -942,19 +945,21 @@ export async function saveConversationMessages(params: {
                 : {}),
         });
     } catch (error) {
+        const code =
+            typeof (error as { code?: unknown })?.code === "string"
+                ? ((error as { code: string }).code as BetterAgentError["code"])
+                : undefined;
+        const status =
+            typeof (error as { status?: unknown })?.status === "number"
+                ? (error as { status: number }).status
+                : undefined;
+
         throw BetterAgentError.wrap({
             err: error,
             message: "Failed to save conversation messages.",
             opts: {
-                code:
-                    error instanceof BetterAgentError && error.code !== undefined
-                        ? error.code
-                        : typeof (error as { code?: unknown })?.code === "string"
-                          ? ((error as { code: string }).code as BetterAgentError["code"])
-                          : "INTERNAL",
-                ...(typeof (error as { status?: unknown })?.status === "number"
-                    ? { status: (error as { status: number }).status }
-                    : {}),
+                ...(code !== undefined ? { code } : {}),
+                ...(status !== undefined ? { status } : {}),
                 context: {
                     conversationId: params.conversationId,
                     agentName: params.agentName,

--- a/packages/core/src/run/registry.ts
+++ b/packages/core/src/run/registry.ts
@@ -16,16 +16,14 @@ export function createAgentRegistry(
 
 export function resolveAgentFromRegistry(
     agents: ReadonlyMap<string, AnyAgentDefinition>,
-    agent: string | AnyAgentDefinition,
+    agentName: string,
     traceAt: string,
 ): AnyAgentDefinition {
-    const resolved =
-        typeof agent === "string" ? agents.get(agent) : (agents.get(agent.name) ?? agent);
+    const resolved = agents.get(agentName);
     if (resolved) {
         return resolved;
     }
 
-    const agentName = typeof agent === "string" ? agent : agent.name;
     throw BetterAgentError.fromCode("NOT_FOUND", `Agent '${agentName}' does not exist.`, {
         context: { agentName },
         trace: [{ at: traceAt }],

--- a/packages/core/src/run/runtime.ts
+++ b/packages/core/src/run/runtime.ts
@@ -410,6 +410,7 @@ export function createRuntime<const TAgents extends readonly AnyAgentDefinition[
                 agent,
                 "core.run.createRuntime.run",
             ) as ContextBoundAgent<TContext>;
+
             if (
                 runOptions.conversationId !== undefined &&
                 runOptions.conversationId.trim().length === 0
@@ -450,9 +451,7 @@ export function createRuntime<const TAgents extends readonly AnyAgentDefinition[
                     resolvedAgent,
                     runOptions.context,
                 );
-                const runPersistence = runOptions.persistence;
-                const resolvedConversations =
-                    runPersistence?.conversations ?? options.conversations;
+                const resolvedConversations = resolvedPersistence?.conversations;
                 const conversationInput = await loadConversationMessages({
                     input: runOptions.input,
                     caps: resolvedAgent.model.caps,
@@ -544,6 +543,7 @@ export function createRuntime<const TAgents extends readonly AnyAgentDefinition[
                 agent,
                 "core.run.createRuntime.stream",
             ) as ContextBoundAgent<TContext>;
+
             if (
                 runOptions.conversationId !== undefined &&
                 runOptions.conversationId.trim().length === 0
@@ -560,7 +560,12 @@ export function createRuntime<const TAgents extends readonly AnyAgentDefinition[
 
             const queue = createAsyncEventQueue<Event>();
             const runPersistence = runOptions.persistence;
-            const streamStore = runPersistence?.stream ?? options.stream;
+            const resolvedPersistence = buildPersistence(runPersistence, {
+                stream: options.stream,
+                conversations: options.conversations,
+                runtimeState: options.runtimeState,
+            });
+            const streamStore = resolvedPersistence?.stream;
             const execution = createRuntimeExecutionContext({
                 resolvedAgent,
                 conversationId: runOptions.conversationId,
@@ -570,12 +575,6 @@ export function createRuntime<const TAgents extends readonly AnyAgentDefinition[
                 queueSignal: streamLifecycle === "detached" ? runOptions.signal : undefined,
                 streamStore,
                 queue,
-            });
-
-            const resolvedPersistence = buildPersistence(runPersistence, {
-                stream: streamStore,
-                conversations: options.conversations,
-                runtimeState: options.runtimeState,
             });
 
             const result = (async (): Promise<RunResult> => {
@@ -592,8 +591,7 @@ export function createRuntime<const TAgents extends readonly AnyAgentDefinition[
                         resolvedAgent,
                         runOptions.context,
                     );
-                    const resolvedConversations =
-                        runPersistence?.conversations ?? options.conversations;
+                    const resolvedConversations = resolvedPersistence?.conversations;
                     const conversationInput = await loadConversationMessages({
                         input: runOptions.input,
                         caps: resolvedAgent.model.caps,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `single_turn_only` to keep only the latest turn and overwrite stored history. Cleans up runtime persistence and agent resolution for more predictable behavior.

- **Bug Fixes**
  - `single_turn_only`: `loadConversationMessages` returns only the current turn; runtime overwrites prior history with the latest user turn.

- **Refactors**
  - Use `buildPersistence` consistently in `runtime` for conversations and stream.
  - `resolveAgentFromRegistry` now resolves by agent name string only.
  - Simplified instruction handling in `agent-loop`.
  - Stream persistence emitter no longer suppresses append errors.
  - Error wrapping in `saveConversationMessages` preserves `code`/`status` when present.

<sup>Written for commit 74d3cdaa56e705dd46875133bea611a57a452be2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

