### PR TITLE
fix(docs): increase MCP route max duration

### DIFF
--- a/docs/app/api/docs/mcp/route.ts
+++ b/docs/app/api/docs/mcp/route.ts
@@ -11,3 +11,5 @@ export const { GET, POST, DELETE } = createDocsMCPAPI({
 });
 
 export const revalidate = false;
+
+export const maxDuration = 800;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase the `maxDuration` for the docs MCP API route to 800 seconds to prevent Vercel timeouts on long-running requests.

<sup>Written for commit ea7ba56c04d2f570cf7c2c4d5d3300fae8d73095. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

