### PR TITLE
fix(docs): hide folder index links and code scrollbars

### DIFF
--- a/docs/app/_components/cta-section.tsx
+++ b/docs/app/_components/cta-section.tsx
@@ -275,7 +275,7 @@ export default function CtaSection() {
             className="relative mx-auto w-full max-w-[76rem] px-5 pt-8 pb-8 sm:px-8 sm:pt-12 sm:pb-12"
             ref={sectionRef}
         >
-            <div className="relative overflow-hidden rounded-2xl bg-black p-4 md:p-8">
+            <div className="relative overflow-hidden rounded-2xl bg-black p-4 px-2 md:p-8">
                 <Image
                     alt=""
                     aria-hidden="true"

--- a/docs/app/_components/primitives-code-block.tsx
+++ b/docs/app/_components/primitives-code-block.tsx
@@ -18,7 +18,7 @@ export default async function PrimitivesCodeBlock({ code, filename }: Primitives
 
     return (
         <div
-            className="code-demo-pane my-0 flex h-[22rem] max-h-[22rem] flex-col overflow-hidden border border-[color:var(--border)] sm:h-[24rem] sm:max-h-[24rem]"
+            className="code-demo-pane my-0 flex flex-col overflow-hidden border border-[color:var(--border)] sm:h-[24rem] sm:max-h-[24rem]"
             style={{ background: "var(--code-block-bg)" }}
         >
             <div
@@ -33,7 +33,7 @@ export default async function PrimitivesCodeBlock({ code, filename }: Primitives
                 </span>
             </div>
             <div
-                className="primitives-shiki min-h-0 flex-1 overflow-auto pt-3 pr-4 pb-4 sm:pt-4 sm:pr-5 sm:pb-5"
+                className="primitives-shiki primitive-scrollbar-hidden min-h-0 flex-1 overflow-auto pt-3 pr-4 pb-4 sm:pt-4 sm:pr-5 sm:pb-5"
                 dangerouslySetInnerHTML={{ __html: html }}
             />
         </div>

--- a/docs/app/_components/primitives-tabs.tsx
+++ b/docs/app/_components/primitives-tabs.tsx
@@ -43,7 +43,7 @@ export default function PrimitivesTabs({ panels, tabs }: PrimitivesTabsProps) {
                 </div>
             </div>
 
-            <div aria-labelledby={`primitive-tab-${activeTab}`} role="tabpanel">
+            <div aria-labelledby={`primitive-tab-${activeTab}`} className="overflow-hidden" role="tabpanel">
                 {panels[activeTab]}
             </div>
         </div>

--- a/docs/app/_components/primitives-tabs.tsx
+++ b/docs/app/_components/primitives-tabs.tsx
@@ -43,7 +43,11 @@ export default function PrimitivesTabs({ panels, tabs }: PrimitivesTabsProps) {
                 </div>
             </div>
 
-            <div aria-labelledby={`primitive-tab-${activeTab}`} className="overflow-hidden" role="tabpanel">
+            <div
+                aria-labelledby={`primitive-tab-${activeTab}`}
+                className="overflow-hidden"
+                role="tabpanel"
+            >
                 {panels[activeTab]}
             </div>
         </div>

--- a/docs/app/globals.css
+++ b/docs/app/globals.css
@@ -1334,7 +1334,9 @@ aside#nd-sidebar-mobile [data-radix-scroll-area-viewport] button:hover {
 
 .primitives-shiki .shiki {
     margin: 0;
-    overflow-x: auto;
+    min-width: 100%;
+    width: max-content;
+    overflow: visible;
     background: transparent !important;
     color: color-mix(in srgb, var(--shiki-light) 76%, var(--foreground) 24%) !important;
     font-family: var(--font-geist-mono), ui-monospace, monospace;
@@ -1344,7 +1346,6 @@ aside#nd-sidebar-mobile [data-radix-scroll-area-viewport] button:hover {
 
 .primitives-shiki .shiki code {
     display: block;
-    min-width: max-content;
 }
 
 .primitives-shiki .shiki span {
@@ -1405,17 +1406,6 @@ aside#nd-sidebar-mobile [data-radix-scroll-area-viewport] button:hover {
 }
 
 .primitive-scrollbar-hidden::-webkit-scrollbar {
-    display: none;
-}
-
-:is(#nd-sidebar, aside#nd-sidebar-mobile)
-    :is(
-        a[href="/docs/concepts"],
-        a[href="/docs/providers"],
-        a[href="/docs/database"],
-        a[href="/docs/integrations"],
-        a[href="/docs/plugins"]
-    ) {
     display: none;
 }
 

--- a/docs/bun.lock
+++ b/docs/bun.lock
@@ -1,12 +1,13 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "docs",
       "dependencies": {
-        "@farming-labs/docs": "^0.1.66",
-        "@farming-labs/next": "^0.1.66",
-        "@farming-labs/theme": "^0.1.66",
+        "@farming-labs/docs": "0.1.72",
+        "@farming-labs/next": "0.1.72",
+        "@farming-labs/theme": "0.1.72",
         "@vercel/analytics": "^1.5.0",
         "@vercel/speed-insights": "^1.2.0",
         "geist": "^1.7.0",
@@ -55,11 +56,11 @@
 
     "@emnapi/runtime": ["@emnapi/runtime@1.10.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA=="],
 
-    "@farming-labs/docs": ["@farming-labs/docs@0.1.66", "", { "dependencies": { "@clack/prompts": "^0.9.1", "@modelcontextprotocol/sdk": "1.29.0", "@scalar/core": "^0.4.3", "gray-matter": "^4.0.3", "jiti": "^2.6.1", "picocolors": "^1.1.1", "zod": "^3.25.76" }, "bin": { "docs": "dist/cli/index.mjs" } }, "sha512-TYBM0EwpTUiICqRNKyh515rVM2TT4MlpDI141N36tIrixz0KowN9Ts8R0RpAKEqQ/P3tf6NgwlAAYHOEgOpJxA=="],
+    "@farming-labs/docs": ["@farming-labs/docs@0.1.72", "", { "dependencies": { "@clack/prompts": "^0.9.1", "@modelcontextprotocol/sdk": "1.29.0", "@scalar/core": "^0.4.3", "gray-matter": "^4.0.3", "jiti": "^2.6.1", "picocolors": "^1.1.1", "zod": "^3.25.76" }, "bin": { "docs": "dist/cli/index.mjs" } }, "sha512-culnwS1Qf0P7wG67bILLICcdjegXl72w2zJ1mqVzmRPgKT4P+9BHeFSQEQrtWj5VMu8PIqzLsiwK/HKiycMUrg=="],
 
-    "@farming-labs/next": ["@farming-labs/next@0.1.66", "", { "dependencies": { "@mdx-js/loader": "^3.1.0", "@mdx-js/react": "^3.1.0", "@next/mdx": "^16.1.6", "@scalar/nextjs-api-reference": "0.10.3", "fumadocs-core": "^16.6.1", "fumadocs-openapi": "^10.7.0", "fumadocs-ui": "^16.6.1", "gray-matter": "^4.0.3", "remark-frontmatter": "^5.0.0", "remark-gfm": "^4.0.1", "remark-mdx-frontmatter": "^5.0.0" }, "peerDependencies": { "@farming-labs/docs": ">=0.0.1", "@farming-labs/theme": ">=0.0.1", "next": ">=16.0.0", "react": ">=19.2.0", "react-dom": ">=19.2.0" } }, "sha512-9eLyOdBtjJ9oWc6UnSpzGj8T11eAU5Io5IFm9i1JUSODAAgAq4eX9WPo2sV73TkcHQDk49AkeNf7CCCjUWqK5w=="],
+    "@farming-labs/next": ["@farming-labs/next@0.1.72", "", { "dependencies": { "@mdx-js/loader": "^3.1.0", "@mdx-js/react": "^3.1.0", "@next/mdx": "^16.1.6", "@scalar/nextjs-api-reference": "0.10.3", "fumadocs-core": "^16.6.1", "fumadocs-openapi": "^10.7.0", "fumadocs-ui": "^16.6.1", "gray-matter": "^4.0.3", "remark-frontmatter": "^5.0.0", "remark-gfm": "^4.0.1", "remark-mdx-frontmatter": "^5.0.0" }, "peerDependencies": { "@farming-labs/docs": ">=0.0.1", "@farming-labs/theme": ">=0.0.1", "next": ">=16.0.0", "react": ">=19.2.0", "react-dom": ">=19.2.0" } }, "sha512-kb5g0RGeq+FdgpNqsLCeafKf3CWVVIMwTRF+5/bzWLvuzUy4Fo4Z23bXTy607qDbOTuQH4uNqlGUYWMBIbGIuQ=="],
 
-    "@farming-labs/theme": ["@farming-labs/theme@0.1.66", "", { "dependencies": { "fumadocs-core": "^16.6.1", "fumadocs-ui": "^16.6.1", "gray-matter": "^4.0.3", "sugar-high": "^0.9.5" }, "peerDependencies": { "@farming-labs/docs": ">=0.0.1", "next": ">=16.0.0", "react": ">=19.2.0", "react-dom": ">=19.2.0" } }, "sha512-eNk+UkEe3fdncowTSM9AgW4N3LZuueRyxO56sjUK2QW69Zuxl1S44qFANmqfksRAT8bID6MCq4gDf0lgjavpEg=="],
+    "@farming-labs/theme": ["@farming-labs/theme@0.1.72", "", { "dependencies": { "fumadocs-core": "^16.6.1", "fumadocs-ui": "^16.6.1", "gray-matter": "^4.0.3", "sugar-high": "^0.9.5" }, "peerDependencies": { "@farming-labs/docs": ">=0.0.1", "next": ">=16.0.0", "react": ">=19.2.0", "react-dom": ">=19.2.0" } }, "sha512-d3bM3MvFHrU7XZFZvMGYgoJyufeEJ7oW4qmW+x2IgA+61W3BJblR5u+FWq08e1fuHyctPZXnjtulnavNnFIkIg=="],
 
     "@floating-ui/core": ["@floating-ui/core@1.7.5", "", { "dependencies": { "@floating-ui/utils": "^0.2.11" } }, "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ=="],
 

--- a/docs/docs.config.tsx
+++ b/docs/docs.config.tsx
@@ -353,7 +353,7 @@ export default defineDocs({
     },
     sidebar: {
         collapsible: false,
-        folderIndexBehavior: "toggle",
+        folderIndexBehavior: "hidden",
         banner: <SidebarReleaseBanner />,
     },
 });

--- a/docs/package.json
+++ b/docs/package.json
@@ -10,9 +10,9 @@
         "typecheck": "tsc -p tsconfig.json --noEmit"
     },
     "dependencies": {
-        "@farming-labs/docs": "^0.1.66",
-        "@farming-labs/next": "^0.1.66",
-        "@farming-labs/theme": "^0.1.66",
+        "@farming-labs/docs": "0.1.72",
+        "@farming-labs/next": "0.1.72",
+        "@farming-labs/theme": "0.1.72",
         "@vercel/analytics": "^1.5.0",
         "@vercel/speed-insights": "^1.2.0",
         "geist": "^1.7.0",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hide folder index items in the docs sidebar and remove horizontal scrollbars in code blocks and tab panels to clean up the reading experience. Also bumps `@farming-labs/*` docs packages to 0.1.72.

- **Bug Fixes**
  - Sidebar: hide auto-generated folder index links via `folderIndexBehavior: "hidden"` and remove ad‑hoc CSS.
  - Code blocks: adjust Shiki styles to prevent horizontal overflow and hide scrollbars using `primitive-scrollbar-hidden`; contain content in tab panels with `overflow-hidden`.
  - Layout: small padding and height tweaks to avoid overflow on small screens.

- **Dependencies**
  - Upgrade `@farming-labs/docs`, `@farming-labs/next`, and `@farming-labs/theme` to `0.1.72`.

<sup>Written for commit cfcb22fa09a15e1bc594323dfa988c87cd4b7a45. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

