### PR TITLE
docs: use agent-scoped runs

### DIFF
--- a/docs/app/docs/concepts/client/page.mdx
+++ b/docs/app/docs/concepts/client/page.mdx
@@ -203,13 +203,13 @@ See [Memory](/docs/concepts/memory) for setup.
 Abort an active run from the client.
 
 ```typescript
-await client.runs.abort("run_123");
+await client.agent("support").abort("run_123");
 ```
 
 Resume a stored stream by run id.
 
 ```typescript
-for await (const event of client.runs.resumeStream({
+for await (const event of client.agent("support").resumeStream({
   runId: "run_123",
   afterSequence: 42,
 })) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated the client docs to use agent-scoped run APIs so examples match the current SDK and clarify run scoping.
Replaced `client.runs.abort`/`client.runs.resumeStream` with `client.agent("support").abort` and `client.agent("support").resumeStream`.

<sup>Written for commit 9c6894ffee386c978e8b4bb7306cece502e0d960. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

